### PR TITLE
Allow special characters in password field

### DIFF
--- a/src/app/change-password/page.tsx
+++ b/src/app/change-password/page.tsx
@@ -84,7 +84,7 @@ export default function ChangePasswordPage() {
               className="mt-1 block w-full rounded-md border border-silver px-3 py-2 text-sm shadow-sm focus:border-gold focus:outline-none dark:border-silver/30 dark:bg-navy-light"
             />
             <p className="mt-1 text-xs text-silver">
-              At least 8 characters, letters and numbers only
+              At least 8 characters
             </p>
           </div>
 

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -187,7 +187,7 @@ function RegisterForm() {
             className="mt-1 block w-full rounded-md border border-silver px-3 py-2 text-sm shadow-sm focus:border-gold focus:outline-none dark:border-silver/30 dark:bg-navy-light"
           />
           <p className="mt-1 text-xs text-silver">
-            At least 8 characters, letters and numbers only
+            At least 8 characters
           </p>
         </div>
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,7 +10,7 @@ import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { sendVerificationEmail } from "@/lib/email";
 
-const ALPHANUMERIC_RE = /^[a-zA-Z0-9]+$/;
+const PRINTABLE_RE = /^[a-zA-Z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~ ]+$/;
 
 const validatePassword = createAuthMiddleware(async (ctx) => {
   if (
@@ -24,9 +24,9 @@ const validatePassword = createAuthMiddleware(async (ctx) => {
   const password =
     (body?.password as string) ?? (body?.newPassword as string);
 
-  if (password && !ALPHANUMERIC_RE.test(password)) {
+  if (password && !PRINTABLE_RE.test(password)) {
     throw new APIError("BAD_REQUEST", {
-      message: "Password must contain only letters and numbers",
+      message: "Password must contain only printable characters",
     });
   }
 });


### PR DESCRIPTION
## Summary

- Widen password validation to accept all printable characters (symbols, spaces) instead of only alphanumeric
- Update UI hint text to remove the outdated "letters and numbers only" restriction
- Closes #13

## Changes

- **auth.ts**: Replace `ALPHANUMERIC_RE` (`/^[a-zA-Z0-9]+$/`) with `PRINTABLE_RE` covering `!@#$%^&*()_+-=[]{}|;:'",.<>/?~` and spaces; update error message to "Password must contain only printable characters"
- **register/page.tsx**: Change hint from "At least 8 characters, letters and numbers only" to "At least 8 characters"
- **change-password/page.tsx**: Same hint text update

## Test Plan

- [x] Register a new account with a password containing special characters (e.g. `P@ssw0rd!#$`)
- [x] Change password to one with special characters
- [x] Verify passwords with only letters/numbers still work
- [x] Verify hint text on both forms reads "At least 8 characters"
- [x] Confirm server rejects passwords shorter than 8 characters