### PR TITLE
feat: add confirmation dialogs for destructive admin actions

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import { useSession, authClient } from "@/lib/auth-client";
+import ConfirmDialog from "@/components/ConfirmDialog";
 
 interface UserRecord {
   id: string;
@@ -50,6 +51,22 @@ export default function AdminPage() {
   const [banDuration, setBanDuration] = useState("permanent");
   const [banError, setBanError] = useState("");
   const [revokeError, setRevokeError] = useState("");
+
+  const [pendingRole, setPendingRole] = useState<{
+    userId: string;
+    name: string;
+    oldRole: string;
+    newRole: string;
+  } | null>(null);
+  const [inviteConfirmOpen, setInviteConfirmOpen] = useState(false);
+  const [unbanTarget, setUnbanTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<{
+    token: string;
+    email: string;
+  } | null>(null);
 
   const role = session
     ? ((session.user as { role?: string }).role ?? "user")
@@ -164,8 +181,7 @@ export default function AdminPage() {
     }
   }
 
-  async function handleRevoke(token: string, email: string) {
-    if (!window.confirm(`Revoke invite to ${email}?`)) return;
+  async function handleRevoke(token: string) {
     setRevokeError("");
     try {
       const res = await fetch(`/api/invites/${token}`, {
@@ -186,8 +202,7 @@ export default function AdminPage() {
     }
   }
 
-  async function handleInvite(e: React.FormEvent) {
-    e.preventDefault();
+  async function handleInvite() {
     setInviteError("");
     setInviteSuccess("");
     setInviteLoading(true);
@@ -247,7 +262,13 @@ export default function AdminPage() {
       {/* Send Invite */}
       <section className="mb-8">
         <h2 className="mb-4 text-lg font-semibold">Send Invite</h2>
-        <form onSubmit={handleInvite} className="flex flex-wrap gap-3">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            setInviteConfirmOpen(true);
+          }}
+          className="flex flex-wrap gap-3"
+        >
           <input
             type="email"
             required
@@ -346,7 +367,14 @@ export default function AdminPage() {
                       <select
                         value={u.role ?? "user"}
                         disabled={u.id === session.user.id}
-                        onChange={(e) => handleRoleChange(u.id, e.target.value)}
+                        onChange={(e) =>
+                          setPendingRole({
+                            userId: u.id,
+                            name: u.name,
+                            oldRole: u.role ?? "user",
+                            newRole: e.target.value,
+                          })
+                        }
                         className="rounded border border-silver/30 bg-transparent px-2 py-0.5 text-sm capitalize disabled:opacity-50 dark:border-silver/20"
                       >
                         <option value="user">User</option>
@@ -381,7 +409,9 @@ export default function AdminPage() {
                       (ROLE_HIERARCHY[u.role ?? "user"] ?? 0) < callerLevel && (
                         u.banned ? (
                           <button
-                            onClick={() => handleUnban(u.id)}
+                            onClick={() =>
+                              setUnbanTarget({ id: u.id, name: u.name })
+                            }
                             className="rounded border border-field-green px-2 py-0.5 text-xs text-field-green hover:bg-field-green/10"
                           >
                             Unban
@@ -449,7 +479,12 @@ export default function AdminPage() {
                     <td className="py-2">
                       {isPending && (
                         <button
-                          onClick={() => handleRevoke(inv.token, inv.email)}
+                          onClick={() =>
+                            setRevokeTarget({
+                              token: inv.token,
+                              email: inv.email,
+                            })
+                          }
                           className="rounded border border-crimson px-2 py-0.5 text-xs text-crimson hover:bg-crimson/10"
                         >
                           Revoke
@@ -463,6 +498,69 @@ export default function AdminPage() {
           </table>
         </div>
       </section>
+
+      {/* Role Change Confirmation */}
+      <ConfirmDialog
+        open={pendingRole !== null}
+        title="Change role?"
+        message={
+          pendingRole
+            ? `Change ${pendingRole.name}\u2019s role from ${pendingRole.oldRole} to ${pendingRole.newRole}?`
+            : ""
+        }
+        confirmLabel="Change Role"
+        onConfirm={() => {
+          if (pendingRole) {
+            handleRoleChange(pendingRole.userId, pendingRole.newRole);
+          }
+          setPendingRole(null);
+        }}
+        onCancel={() => setPendingRole(null)}
+      />
+
+      {/* Send Invite Confirmation */}
+      <ConfirmDialog
+        open={inviteConfirmOpen}
+        title="Send invite?"
+        message={`Send invite to ${inviteEmail} as ${inviteRole}?`}
+        confirmLabel="Send Invite"
+        onConfirm={() => {
+          setInviteConfirmOpen(false);
+          handleInvite();
+        }}
+        onCancel={() => setInviteConfirmOpen(false)}
+      />
+
+      {/* Unban Confirmation */}
+      <ConfirmDialog
+        open={unbanTarget !== null}
+        title="Unban user?"
+        message={unbanTarget ? `Unban ${unbanTarget.name}?` : ""}
+        confirmLabel="Unban"
+        onConfirm={() => {
+          if (unbanTarget) {
+            handleUnban(unbanTarget.id);
+          }
+          setUnbanTarget(null);
+        }}
+        onCancel={() => setUnbanTarget(null)}
+      />
+
+      {/* Revoke Invite Confirmation */}
+      <ConfirmDialog
+        open={revokeTarget !== null}
+        title="Revoke invite?"
+        message={revokeTarget ? `Revoke invite to ${revokeTarget.email}?` : ""}
+        confirmLabel="Revoke"
+        danger
+        onConfirm={() => {
+          if (revokeTarget) {
+            handleRevoke(revokeTarget.token);
+          }
+          setRevokeTarget(null);
+        }}
+        onCancel={() => setRevokeTarget(null)}
+      />
 
       {/* Ban Modal */}
       {banTarget && (

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,48 @@
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  danger?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  danger = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-lg dark:bg-navy-light">
+        <h3 className="mb-4 text-lg font-semibold">{title}</h3>
+        <p className="mb-6 text-sm text-silver">{message}</p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="rounded-md border border-silver px-4 py-2 text-sm hover:bg-silver/10 dark:border-silver/30"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className={
+              danger
+                ? "rounded-md bg-crimson px-4 py-2 text-sm font-medium text-white hover:bg-crimson/90"
+                : "rounded-md bg-navy px-4 py-2 text-sm font-medium text-gold hover:bg-navy-dark dark:bg-gold dark:text-navy dark:hover:bg-gold-dark"
+            }
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Created reusable `ConfirmDialog` component matching the existing ban modal's visual style
- Wired confirmation dialogs into 4 admin actions: role change, send invite, unban, and revoke invite
- Replaced inconsistent `window.confirm()` on revoke with the styled modal

## Test plan
- [x] Role change: select dropdown shows confirmation → Cancel reverts select → Confirm fires API
- [x] Send invite: form submit shows confirmation → Cancel aborts → Confirm sends invite
- [x] Unban: button shows confirmation → Cancel aborts → Confirm unbans user
- [x] Revoke invite: button shows styled danger modal → Cancel aborts → Confirm revokes
- [x] Ban modal unchanged (still has reason + duration fields)
- [x] `npm run build` passes
- [x] `npm test` — all 136 tests pass

Closes #24