### PR TITLE
Add profile completion prompt on home page

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -9,15 +9,54 @@ export default function HelloPage() {
   const router = useRouter();
   const { data: session, isPending } = useSession();
   const [email, setEmail] = useState("");
+  const [profileFields, setProfileFields] = useState<{
+    location: string;
+    platoon: string;
+    yearsServed: string;
+  }>({ location: "", platoon: "", yearsServed: "" });
+  const [profileLoaded, setProfileLoaded] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
     if (!session) return;
     fetch(`/api/users/${session.user.id}`)
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
-        if (data?.email) setEmail(data.email);
+        if (!data) return;
+        if (data.email) setEmail(data.email);
+        setProfileFields({
+          location: data.location ?? "",
+          platoon: data.platoon ?? "",
+          yearsServed: data.yearsServed ?? "",
+        });
+        setProfileLoaded(true);
       });
   }, [session]);
+
+  const missingFields: string[] = [];
+  if (profileLoaded) {
+    if (!profileFields.location) missingFields.push("location");
+    if (!profileFields.platoon) missingFields.push("platoon");
+    if (!profileFields.yearsServed) missingFields.push("years served");
+  }
+
+  useEffect(() => {
+    if (!profileLoaded || missingFields.length === 0) return;
+    const key = "profile-prompt-dismissed";
+    const stored = localStorage.getItem(key);
+    const current = missingFields.slice().sort().join(",");
+    if (stored === current) {
+      setDismissed(true);
+    } else {
+      setDismissed(false);
+    }
+  }, [profileLoaded, missingFields.join(",")]);
+
+  function handleDismiss() {
+    const current = missingFields.slice().sort().join(",");
+    localStorage.setItem("profile-prompt-dismissed", current);
+    setDismissed(true);
+  }
 
   if (isPending) {
     return (
@@ -46,6 +85,41 @@ export default function HelloPage() {
             Welcome to Berlin Reunion
           </p>
         </div>
+
+        {profileLoaded && missingFields.length > 0 && !dismissed && (
+          <div className="relative rounded-lg border border-gold-dark/30 bg-gold/10 p-4">
+            <button
+              onClick={handleDismiss}
+              className="absolute right-2 top-2 text-cream/50 hover:text-cream/70"
+              aria-label="Dismiss"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+            <h2 className="font-[family-name:var(--font-oswald)] text-sm font-semibold uppercase tracking-wider text-gold">
+              Complete Your Profile
+            </h2>
+            <p className="mt-1 text-sm text-cream/60">
+              Your {missingFields.join(", ")} {missingFields.length === 1 ? "is" : "are"} still empty.
+            </p>
+            <Link
+              href="/profile"
+              className="mt-2 inline-block text-sm font-medium text-gold hover:text-gold-light"
+            >
+              Edit Profile &rarr;
+            </Link>
+          </div>
+        )}
 
         <div className="rounded-lg border border-gold-dark/20 p-4">
           <dl className="space-y-2 text-sm">


### PR DESCRIPTION
## Summary

- Show a dismissible banner on `/home` when any profile fields (location, platoon, years served) are empty
- Banner links to `/profile` and names the specific missing fields
- Dismissal persists in localStorage, keyed by which fields are missing so the prompt re-appears if new empty fields are detected

Closes #60

## Changes

- **home/page.tsx**: Extend existing user fetch to capture `location`, `platoon`, `yearsServed` from the API response
- **home/page.tsx**: Add `missingFields` computation and localStorage-based dismissal logic
- **home/page.tsx**: Render gold-tinted dismissible banner above the profile card with dynamic copy and link to `/profile`

## Test Plan

- [x] Log in as a user with empty profile fields → banner appears on `/home`
- [x] Banner lists the correct missing fields with proper grammar (is/are)
- [x] Click "Edit Profile →" link → navigates to `/profile`
- [x] Click X dismiss button → banner disappears and stays hidden on refresh
- [x] Fill in one missing field but leave others empty → banner re-appears (different missing fields)
- [x] Fill in all three fields → banner does not appear
- [x] `npm run build` passes with no errors