### PR TITLE
Add resend button for expired invites

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -92,6 +92,12 @@ export default function AdminPage() {
 		token: string;
 		email: string;
 	} | null>(null);
+	const [resendTarget, setResendTarget] = useState<{
+		email: string;
+		role: string;
+	} | null>(null);
+	const [resendError, setResendError] = useState("");
+	const [resendSuccess, setResendSuccess] = useState("");
 	const [verifyTarget, setVerifyTarget] = useState<{
 		id: string;
 		name: string;
@@ -426,6 +432,34 @@ export default function AdminPage() {
 			);
 		} catch {
 			setRevokeError("Failed to revoke invite");
+		}
+	}
+
+	async function handleResend() {
+		if (!resendTarget) return;
+		setResendError("");
+		setResendSuccess("");
+		try {
+			const res = await fetch("/api/invites", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					email: resendTarget.email,
+					role: resendTarget.role,
+				}),
+			});
+			if (!res.ok) {
+				const data = await res.json();
+				setResendError(data.error ?? "Failed to resend invite");
+				setResendTarget(null);
+				return;
+			}
+			setResendSuccess(`Invite resent to ${resendTarget.email}`);
+			setResendTarget(null);
+			loadInvites(invitesPage);
+		} catch {
+			setResendError("Failed to resend invite");
+			setResendTarget(null);
 		}
 	}
 
@@ -939,6 +973,12 @@ export default function AdminPage() {
 				{revokeError && (
 					<p className="mb-3 text-sm text-crimson">{revokeError}</p>
 				)}
+				{resendError && (
+					<p className="mb-3 text-sm text-crimson">{resendError}</p>
+				)}
+				{resendSuccess && (
+					<p className="mb-3 text-sm text-field-green">{resendSuccess}</p>
+				)}
 				<div className="overflow-x-auto">
 					<table className="w-full text-left text-sm">
 						<thead>
@@ -995,6 +1035,20 @@ export default function AdminPage() {
 														Revoke
 													</button>
 												)}
+												{!inv.used &&
+													new Date(inv.expiresAt) < new Date() && (
+														<button
+															onClick={() =>
+																setResendTarget({
+																	email: inv.email,
+																	role: inv.role,
+																})
+															}
+															className="rounded border border-gold-dark/40 px-2 py-0.5 text-xs text-cream/70 hover:border-gold/60 hover:text-gold hover:bg-gold-dark/10"
+														>
+															Resend
+														</button>
+													)}
 											</td>
 										</tr>
 									);
@@ -1091,6 +1145,22 @@ export default function AdminPage() {
 					setRevokeTarget(null);
 				}}
 				onCancel={() => setRevokeTarget(null)}
+			/>
+
+			{/* Resend Invite Confirmation */}
+			<ConfirmDialog
+				open={resendTarget !== null}
+				title="Resend invite?"
+				message={
+					resendTarget
+						? `Resend invite to ${resendTarget.email}?`
+						: ""
+				}
+				confirmLabel="Resend"
+				onConfirm={() => {
+					handleResend();
+				}}
+				onCancel={() => setResendTarget(null)}
 			/>
 
 			{/* Reset Password Confirmation */}


### PR DESCRIPTION
## Summary

- Adds a "Resend" button on expired (non-used) invites in the admin dashboard
- Reuses the existing `POST /api/invites` endpoint to create a fresh invite and send a new email
- Old expired invite rows remain in history for audit purposes
- Follows existing confirmation dialog and success/error messaging patterns

## Changes

- **admin/page.tsx**: Add `resendTarget`, `resendError`, `resendSuccess` state following the existing `revokeTarget`/`revokeError` pattern
- **admin/page.tsx**: Add `handleResend()` handler that calls `POST /api/invites` with the expired invite's email and role
- **admin/page.tsx**: Add Resend button in invites table Actions column for expired invites (gold-dark outline styling)
- **admin/page.tsx**: Add `ConfirmDialog` for resend confirmation (non-destructive, no `danger` prop)
- **admin/page.tsx**: Add success/error messages above invites table

## Test Plan

- [x] Verify expired invite rows show a "Resend" button
- [x] Verify pending invite rows still show only "Revoke"
- [x] Verify used invite rows show no action buttons
- [x] Click Resend — confirmation dialog appears with correct email
- [x] Confirm resend — new pending invite row appears, success message shown
- [x] Confirm resend for an already-registered email — error message appears (409)
- [x] Cancel resend — no action taken, dialog closes

Closes #28