### PR TITLE
Fix admin users table horizontal overflow clipping

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -706,7 +706,7 @@ export default function AdminPage() {
 					</select>
 				</div>
 				<div className="overflow-x-auto">
-					<table className="w-full text-left text-sm">
+					<table className="min-w-[1000px] w-full text-left text-sm">
 						<thead>
 							<tr className="border-b border-gold-dark/30">
 								<th className="pb-2 pr-4 font-medium text-cream/70"></th>
@@ -766,7 +766,7 @@ export default function AdminPage() {
 									{usersSortBy === "status" &&
 										(usersSortDir === "asc" ? "▲" : "▼")}
 								</th>
-								<th className="pb-2 font-medium text-cream/70">Actions</th>
+								<th className="pb-2 font-medium text-cream/70 whitespace-nowrap">Actions</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -810,11 +810,11 @@ export default function AdminPage() {
 												{u.name}
 											</Link>
 										</td>
-										<td className="py-2 pr-4 text-cream/50">{u.email}</td>
+										<td className="py-2 pr-4 text-cream/50 max-w-[200px] truncate" title={u.email}>{u.email}</td>
 										<td className="py-2 pr-4 text-cream/80">
 											{u.username ?? "—"}
 										</td>
-										<td className="py-2 pr-4 text-cream/50">
+										<td className="py-2 pr-4 text-cream/50 max-w-[140px] truncate" title={u.location ?? ""}>
 											{u.location ?? "—"}
 										</td>
 										<td className="py-2 pr-4">
@@ -870,7 +870,7 @@ export default function AdminPage() {
 												<span className="text-field-green">Active</span>
 											)}
 										</td>
-										<td className="py-2">
+										<td className="py-2 whitespace-nowrap">
 											{u.id !== session.user.id &&
 												(ROLE_HIERARCHY[u.role ?? "user"] ?? 0) <
 													callerLevel && (


### PR DESCRIPTION
## Summary

- Fix the admin dashboard users table being clipped on the right side in production when user data contains long emails and multi-line locations
- The Actions column (Ban, Reset PW, Delete buttons) was cut off and inaccessible

## Changes

- **admin/page.tsx**: Add `min-w-[1000px]` to users table so `overflow-x-auto` wrapper produces a proper horizontal scrollbar instead of clipping content
- **admin/page.tsx**: Add `max-w-[200px] truncate` to email cells and `max-w-[140px] truncate` to location cells to cap column widths (full text visible on hover via `title` attribute)
- **admin/page.tsx**: Add `whitespace-nowrap` to Actions header and action button cells to keep buttons on a single line

## Test Plan

- [ ] Open the admin dashboard with users that have long email addresses and multi-line locations
- [ ] Verify the table shows a horizontal scrollbar when content exceeds the container width
- [ ] Verify the Actions column (Ban, Reset PW, Delete) is fully visible and not clipped
- [ ] Verify long emails and locations show truncated with ellipsis, and full text appears on hover
- [ ] Verify the table still looks correct with short/minimal data