### PR TITLE
Replace native confirm() with styled delete confirmation modal

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -7,6 +7,7 @@ import CalendarHeader from "@/components/calendar/CalendarHeader";
 import CalendarGrid from "@/components/calendar/CalendarGrid";
 import EventDetailModal from "@/components/calendar/EventDetailModal";
 import EventFormModal from "@/components/calendar/EventFormModal";
+import ConfirmDeleteModal from "@/components/calendar/ConfirmDeleteModal";
 import type { ExpandedEvent, EventDetail, EventFormData } from "@/components/calendar/types";
 
 export default function CalendarPage() {
@@ -21,6 +22,7 @@ export default function CalendarPage() {
 	const [selectedEvent, setSelectedEvent] = useState<ExpandedEvent | null>(null);
 	const [showForm, setShowForm] = useState(false);
 	const [editEvent, setEditEvent] = useState<EventDetail | null>(null);
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
 	const role = session
 		? ((session.user as { role?: string }).role ?? "user")
@@ -102,15 +104,20 @@ export default function CalendarPage() {
 		await fetchEvents();
 	}
 
-	async function handleDelete() {
+	function handleDelete() {
 		if (!selectedEvent) return;
-		if (!confirm("Are you sure you want to delete this event?")) return;
+		setShowDeleteConfirm(true);
+	}
+
+	async function confirmDelete() {
+		if (!selectedEvent) return;
 
 		const res = await fetch(`/api/events/${selectedEvent.eventId}`, {
 			method: "DELETE",
 		});
 
 		if (res.ok) {
+			setShowDeleteConfirm(false);
 			setSelectedEvent(null);
 			await fetchEvents();
 		}
@@ -187,6 +194,15 @@ export default function CalendarPage() {
 						setEditEvent(null);
 					}}
 					onSave={handleSave}
+				/>
+			)}
+
+			{showDeleteConfirm && selectedEvent && (
+				<ConfirmDeleteModal
+					eventTitle={selectedEvent.title}
+					isRecurring={selectedEvent.isRecurring}
+					onConfirm={confirmDelete}
+					onCancel={() => setShowDeleteConfirm(false)}
 				/>
 			)}
 		</div>

--- a/src/components/calendar/ConfirmDeleteModal.tsx
+++ b/src/components/calendar/ConfirmDeleteModal.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+
+interface ConfirmDeleteModalProps {
+	eventTitle: string;
+	isRecurring: boolean;
+	onConfirm: () => Promise<void>;
+	onCancel: () => void;
+}
+
+export default function ConfirmDeleteModal({
+	eventTitle,
+	isRecurring,
+	onConfirm,
+	onCancel,
+}: ConfirmDeleteModalProps) {
+	const [deleting, setDeleting] = useState(false);
+
+	async function handleConfirm() {
+		setDeleting(true);
+		try {
+			await onConfirm();
+		} finally {
+			setDeleting(false);
+		}
+	}
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+			<div className="w-full max-w-sm rounded-lg border border-gold-dark/30 bg-charcoal p-6 shadow-xl">
+				<h3 className="font-[family-name:var(--font-oswald)] text-lg font-semibold uppercase tracking-wider text-gold">
+					Delete Event
+				</h3>
+
+				<p className="mt-3 text-sm text-cream/70">
+					Are you sure you want to delete{" "}
+					<span className="font-medium text-cream/90">{eventTitle}</span>?
+					This action cannot be undone.
+				</p>
+
+				{isRecurring && (
+					<p className="mt-2 rounded border border-red-900/30 bg-red-950/20 px-3 py-2 text-sm text-red-400">
+						This is a recurring event. Deleting it will remove all occurrences in the series.
+					</p>
+				)}
+
+				<div className="mt-5 flex justify-end gap-2">
+					<button
+						type="button"
+						onClick={onCancel}
+						disabled={deleting}
+						className="rounded-md border border-gold-dark/30 px-4 py-1.5 font-[family-name:var(--font-oswald)] text-sm font-medium uppercase tracking-wider text-cream/60 hover:text-cream/80 disabled:opacity-50"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={handleConfirm}
+						disabled={deleting}
+						className="rounded-md border border-red-900/40 bg-red-950/20 px-4 py-1.5 font-[family-name:var(--font-oswald)] text-sm font-medium uppercase tracking-wider text-red-400 hover:border-red-700/60 hover:bg-red-950/40 disabled:opacity-50"
+					>
+						{deleting ? "Deleting..." : "Delete"}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

- Replace the browser-native `confirm()` dialog for event deletion with a custom styled modal matching the app's design system
- Add a recurring event warning so users know the entire series will be removed
- Include a loading state on the Delete button while the request is in flight

Closes #80

## Changes

- **calendar/ConfirmDeleteModal.tsx**: New modal component with charcoal/gold/cream styling, red destructive Delete button, Cancel button, and a recurring event warning banner
- **calendar/page.tsx**: Replace `confirm()` call with `showDeleteConfirm` state that renders the new modal; extract delete logic into `confirmDelete()` async handler

## Test Plan

- [x] Click Delete on a one-time event — modal appears with event title, no recurring warning
- [x] Click Delete on a recurring event — modal shows the "entire series will be deleted" warning
- [x] Click Cancel — modal dismisses, event is not deleted
- [x] Click Delete — button shows "Deleting...", event is removed, modal closes
- [x] Verify modal styling matches EventDetailModal / EventFormModal (borders, colors, fonts)
- [x] Verify `npm run build` succeeds