### PR TITLE
feat: add /api/health endpoint with DB check

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { sql } from "drizzle-orm";
+
+export async function GET() {
+  let dbStatus = "ok";
+  try {
+    db.run(sql`SELECT 1`);
+  } catch {
+    dbStatus = "error";
+  }
+
+  const status = dbStatus === "ok" ? "ok" : "degraded";
+  return NextResponse.json(
+    {
+      status,
+      service: "berlin-reunion",
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+      checks: {
+        database: dbStatus,
+      },
+    },
+    { status: status === "ok" ? 200 : 503 }
+  );
+}


### PR DESCRIPTION
## Summary
Add a health check endpoint for production monitoring.

## Changes
- **src/app/api/health/route.ts**: New Next.js API route with DB connectivity check

## Response Format
```json
{
  "status": "ok",
  "service": "berlin-reunion",
  "uptime": 3600,
  "timestamp": "2026-03-17T00:00:00Z",
  "checks": { "database": "ok" }
}
```

## Test Plan
- [x] `GET /api/health` returns 200 with `status: ok` when DB is accessible
- [x] Returns 503 with `status: degraded` when DB is down
- [x] No auth required

Closes #173